### PR TITLE
Relative date ranges and style fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## [6.0.1] - 2026-06-06
+## [6.1.0] - 2026-06-06
 - Added `ndp-` class prefix to replace all `custom-` prefixs. `custom-` is deprecated and may be removed in a future version.
+- Added `parseHumanDate` for parsing human-readable dates: date math (`now-7d`), ISO 8601 durations (`p7d`), and optional natural language via `setNaturalLanguageParser` (e.g. `chrono-node`).
+- Added `enableEditableDates` to edit the custom range through two inputs that accept a `dateFormat` date or the expressions above, with validation.
+- Added `displaySelectedExpression` to show the relative expressions (e.g. `now-7d - now`) in the main input.
+- `onDateSelectionChanged` (`SelectedDateEvent`) now also emits `startExpr` / `endExpr`.
+- Fixed the selected option not showing as highlighted when reopening the dropdown.
 
 ## [6.0.0] - 2026-01-12
 - Upgraded from Angular 20 to Angular 21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [6.0.1] - 2026-06-06
+- Added `ndp-` class prefix to replace all `custom-` prefixs. `custom-` is deprecated and may be removed in a future version.
+
 ## [6.0.0] - 2026-01-12
 - Upgraded from Angular 20 to Angular 21
 - Upgraded from Angular Material 20 to Angular Material 21

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ In Above example first item of action list is selected and second option is hidd
 #### Note:
 Upon clearing, it resets the minimum and maximum dates, and sets both the range and selectedOption to null.
 
+## Styleing
+
+The project prefixes custom classes with `ndp-`.
+
 
 ## Demo's
 [Demo 1](https://techtose-ng-date-range-picker.netlify.app/dashboards/analytics)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ This will display the Date Range Picker in your default browser.
 | `maxDate` | `Date`| **optional**. To specify max date default is current date +10 years. |
 | `selectedOptionIndex` | `number`| **optional**. To default selected option. (by default it is 3 which is last 30 days.) |
 | `displaySelectedLabel` | `boolean`| **optional**. To show the selected option label instead of date range |
+| `displaySelectedExpression` | `boolean`| **optional**. default `false`. To show the human-readable expressions (e.g. `now-7d - now`) in the main input instead of the date range. `displaySelectedLabel` takes priority when both are true. |
+| `enableEditableDates` | `boolean`| **optional**. default `false`. When `true`, the custom-range footer shows two editable inputs (start/end) that accept a `dateFormat` date, an ISO 8601 duration (`p7d`), or date math (`now-7d`), with validation. See [Editable date inputs](#editable-date-inputs). |
 | `cdkConnectedOverlayPositions` | `ConnectedPosition[]`| **optional**. To control the overlay position |
 | `staticOptionId` | `string`| **optional**. To set id of static options container |
 | `dynamicOptionId` | `string`| **optional**. To set id of dynamic options container |
@@ -142,7 +144,7 @@ This will display the Date Range Picker in your default browser.
 
 | Name | Type     | Description                |
 | :-------- | :------- | :------------------------- |
-| `onDateSelectionChanged` | `DateRange<Date>` | Emits when date selection is changed. And it contains range: DateRange and selectedOption: ISelectDateOption |
+| `onDateSelectionChanged` | `SelectedDateEvent` | Emits when date selection is changed. Contains `range: DateRange`, `selectedOption: ISelectDateOption`, and the human-readable `startExpr` / `endExpr` strings (e.g. `now-7d`, or absolute dates) — `null` on clear. |
 | `dateListOptions` | `ISelectDateOption[]`| Emits pre-defined date action list items for configuration purpose. |
 
 #### Example to configure predefined visibility of predefined date action list items:
@@ -211,6 +213,25 @@ parseHumanDate('3 weeks ago'); // → Date
 
 If no parser is registered, step 3 is simply skipped and `parseHumanDate`
 returns `null` for input only natural language could understand.
+
+### Editable date inputs
+
+Set `enableEditableDates` to `true` to replace the read-only label in the
+custom-range footer with two Material inputs:
+
+```html
+<ng-date-range-picker [enableEditableDates]="true"></ng-date-range-picker>
+```
+
+- Each input accepts a date in `dateFormat` (e.g. `06/06/2026`), an ISO 8601
+  duration (`p7d`), or date math (`now-7d`). Typing a value updates the
+  calendars; **Apply** commits the range.
+- Invalid input shows a Material error and disables **Apply** until both
+  values parse and the start is not after the end.
+- Day-diff options (Today, Last 7 Days, …) pre-fill the inputs with their
+  relative form (`now-7d` .. `now`); other ranges show absolute dates. To give
+  a custom option an explicit relative form, set `startExpr` / `endExpr` on the
+  `ISelectDateOption`.
 
 ## Styleing
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,47 @@ In Above example first item of action list is selected and second option is hidd
 #### Note:
 Upon clearing, it resets the minimum and maximum dates, and sets both the range and selectedOption to null.
 
+## Parsing human-readable dates
+
+The library exports a small, dependency-free `parseHumanDate` helper that turns
+human-readable expressions into a `Date`. It tries, in order:
+
+1. **Date math** (Grafana/Elasticsearch style): `now`, `now-7d`, `now-1M+15d`
+   (units: `y M w d h m s`, where `M` = month and `m` = minute).
+2. **ISO 8601 duration**: `P7D`, `PT1H30M`. Input is upper-cased first, so
+   lowercase (`p7d`) is also accepted. A bare duration resolves relative to the
+   base date — by default into the past (`durationSign: -1`), e.g. `p7d` → 7 days ago.
+3. **Natural language** (`3 weeks ago`) — only if you register a parser (see below).
+
+```typescript
+import { parseHumanDate } from 'ng-material-date-range-picker';
+
+parseHumanDate('now-7d');     // → Date, 7 days before now
+parseHumanDate('p7d');        // → Date, 7 days ago (lowercase ISO accepted)
+parseHumanDate('PT12H', { durationSign: 1 }); // → Date, 12 hours into the future
+```
+
+### Optional natural-language support
+
+`chrono-node` is **not** a required dependency. To enable natural-language
+parsing, install it in your app and register it once at startup:
+
+```bash
+npm i chrono-node
+```
+
+```typescript
+import * as chrono from 'chrono-node';
+import { setNaturalLanguageParser, parseHumanDate } from 'ng-material-date-range-picker';
+
+setNaturalLanguageParser((text, ref) => chrono.parseDate(text, ref));
+
+parseHumanDate('3 weeks ago'); // → Date
+```
+
+If no parser is registered, step 3 is simply skipped and `parseHumanDate`
+returns `null` for input only natural language could understand.
+
 ## Styleing
 
 The project prefixes custom classes with `ndp-`.

--- a/projects/ng-date-picker/package.json
+++ b/projects/ng-date-picker/package.json
@@ -4,7 +4,13 @@
   "description": "This library provides the date range selection with two views.",
   "peerDependencies": {
     "@angular/core": "^21.0.0",
-    "@angular/material": "^21.0.0"
+    "@angular/material": "^21.0.0",
+    "chrono-node": "*"
+  },
+  "peerDependenciesMeta": {
+    "chrono-node": {
+      "optional": true
+    }
   },
   "author": {
     "name": "Aakash Kumar",

--- a/projects/ng-date-picker/src/lib/calendar/calendar.component.css
+++ b/projects/ng-date-picker/src/lib/calendar/calendar.component.css
@@ -9,26 +9,19 @@
 
 .calendar-container {
   width: 100%;
-  display: block;
-  float: left;
+  display: flex;
 }
 
 .first-view,
 .second-view {
-  width: 50%;
-  display: block;
-  float: left;
-}
-
-.first-view,
-.second-view {
+  flex: 1 1 50%;
+  min-width: 0; /* allow each calendar to shrink within its half */
   margin-top: 0.5rem;
 }
 
 @media (max-width: 490px) {
-
-  .first-view,
-  .second-view {
-    width: 100%;
+  /* Stack the two calendar views; align-items: stretch makes each full width. */
+  .calendar-container {
+    flex-direction: column;
   }
 }

--- a/projects/ng-date-picker/src/lib/calendar/calendar.component.ts
+++ b/projects/ng-date-picker/src/lib/calendar/calendar.component.ts
@@ -13,8 +13,10 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   inject,
   Input,
+  Output,
   Renderer2,
   signal,
   ViewChild,
@@ -44,6 +46,9 @@ export class CalendarComponent implements AfterViewInit {
 
   @Input() minDate!: Date;
   @Input() maxDate!: Date;
+
+  /** Emits when the user changes the selection by clicking dates in the views. */
+  @Output() selectedDatesChange = new EventEmitter<DateRange<Date>>();
 
   @ViewChild('firstCalendarView') firstCalendarView!: MatCalendar<Date>;
   @ViewChild('secondCalendarView') secondCalendarView!: MatCalendar<Date>;
@@ -120,6 +125,7 @@ export class CalendarComponent implements AfterViewInit {
       this.isAllowHoverEvent = false;
       this._selectedDates = new DateRange<Date>(selectedDates.start, date);
     }
+    this.selectedDatesChange.emit(this._selectedDates);
     this.cdref.markForCheck();
   }
 

--- a/projects/ng-date-picker/src/lib/model/date-selection-event.model.ts
+++ b/projects/ng-date-picker/src/lib/model/date-selection-event.model.ts
@@ -4,4 +4,12 @@ import { ISelectDateOption } from './select-date-option.model';
 export interface SelectedDateEvent {
   range: DateRange<Date> | null;
   selectedOption: ISelectDateOption | null;
+  /**
+   * Human-readable expression for the range start: the user's own input (e.g.
+   * `now-7d`) when editing, the relative form of a day-diff option, otherwise
+   * the absolute formatted date. `null` when the selection is cleared.
+   */
+  startExpr: string | null;
+  /** Human-readable expression for the range end. See {@link startExpr}. */
+  endExpr: string | null;
 }

--- a/projects/ng-date-picker/src/lib/model/select-date-option.model.ts
+++ b/projects/ng-date-picker/src/lib/model/select-date-option.model.ts
@@ -48,6 +48,20 @@ export interface ISelectDateOption {
    * Used when optionType requires special handling beyond dateDiff.
    */
   callBackFunction?: () => DateRange<Date>;
+
+  /**
+   * Optional date-math/relative expression shown for the range start when
+   * editable inputs are enabled (e.g. `now-7d`). Overrides the value derived
+   * from `dateDiff`. Must be paired with {@link endExpr}.
+   */
+  startExpr?: string;
+
+  /**
+   * Optional date-math/relative expression shown for the range end when
+   * editable inputs are enabled (e.g. `now`). Must be paired with
+   * {@link startExpr}.
+   */
+  endExpr?: string;
 }
 
 /**

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.html
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.html
@@ -67,17 +67,17 @@
             [maxDate]="maxDate"></lib-calendar></div>
       </div>
       <div class="row-2 br-top">
-        <div class="text-end my-2 w-full">
-          <div class="footer-content">
+        <div class="text-end w-full">
+          <div class="footer-content ndp-footer-content">
             <span id="range-label-text">
               {{calendar?.selectedDates?.start | date: dateFormat}}
               @if (calendar?.selectedDates?.end) {
                 <span> - {{calendar.selectedDates?.end | date: dateFormat}} </span>
               }
             </span>
-            <div class="d-inline buttons">
-              <button mat-button mat-raised-button class="p-3 mx-2" (click)="isCustomRange=false;">Cancel</button>
-              <button mat-button mat-raised-button color="primary" class="ms-2 p-3"
+            <div class="buttons">
+              <button mat-button mat-raised-button (click)="isCustomRange=false;">Cancel</button>
+              <button mat-button mat-raised-button color="primary"
                 [class.disabled]="!(calendar?.selectedDates?.start && calendar?.selectedDates?.end)"
                 (click)="updateCustomRange(dateInput,calendar.selectedDates);">&nbsp;Apply&nbsp;</button>
             </div>

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.html
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.html
@@ -3,7 +3,7 @@
 
  * @author Aakash Kumar
  *-->
-<div class="date-picker-main" cdkOverlayOrigin #trigger>
+<div class="date-picker-main ndp-main" cdkOverlayOrigin #trigger>
   <mat-form-field class="w-full" [class]="{'display-hidden':isShowStaticDefaultOptions}" (click)="toggleDateOptionSelectionList($event)">
     <mat-label (click)="toggleDateOptionSelectionList($event)">{{inputLabel}}</mat-label>
     <input matInput readonly="readonly" #dateInput class="cursor-pointer" id="date-input-field">
@@ -22,7 +22,7 @@
         $implicit: visibleOptions(),
         dateInput: dateInput,
         optionId: staticOptionId,
-        className:'w-full custom-ckd-container range-input',
+        className:'w-full custom-ckd-container ndp-cdk-container range-input',
       }"
     ></ng-container>
   }
@@ -39,7 +39,7 @@
           $implicit: visibleOptions(),
           dateInput: dateInput,
           optionId: dynamicOptionId,
-          className:'w-full custom-ckd-container range-input',
+          className:'w-full custom-ckd-container ndp-cdk-container range-input',
         }"
       ></ng-container>
     }
@@ -50,7 +50,7 @@
     [cdkConnectedOverlayPositions]="cdkConnectedOverlayPositions"
     [cdkConnectedOverlayOffsetX]="cdkConnectedOverlayOffsetX" [cdkConnectedOverlayOffsetY]="cdkConnectedOverlayOffsetY"
     (overlayOutsideClick)="toggleCustomDateRangeView()">
-    <div class="custom-ckd-container custom-calendar-container" [class]="{'without-default-opt':hideDefaultOptions}">
+    <div class="custom-ckd-container ndp-cdk-container custom-calendar-container ndp-calendar-container" [class]="{'without-default-opt':hideDefaultOptions}">
       <div class="row-1">
         @if (!hideDefaultOptions) {
           <div class="pt-custom br-right column-1">

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.html
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.html
@@ -53,7 +53,7 @@
     <div class="custom-ckd-container ndp-cdk-container custom-calendar-container ndp-calendar-container" [class]="{'without-default-opt':hideDefaultOptions}">
       <div class="row-1">
         @if (!hideDefaultOptions) {
-          <div class="pt-custom br-right column-1">
+          <div class="pt-custom column-1">
             <ng-container
               *ngTemplateOutlet="dateOptionList;
               context: {
@@ -62,25 +62,24 @@
               }"
             ></ng-container>
           </div>
+          <div class="ndp-column-separator"></div>
         }
         <div class="mt-2 column-2"><lib-calendar [selectedDates]="selectedDates" #calendar [minDate]="minDate"
             [maxDate]="maxDate"></lib-calendar></div>
       </div>
       <div class="row-2 br-top">
-        <div class="text-end w-full">
-          <div class="footer-content ndp-footer-content">
-            <span id="range-label-text">
-              {{calendar?.selectedDates?.start | date: dateFormat}}
-              @if (calendar?.selectedDates?.end) {
-                <span> - {{calendar.selectedDates?.end | date: dateFormat}} </span>
-              }
-            </span>
-            <div class="buttons">
-              <button mat-button mat-raised-button (click)="isCustomRange=false;">Cancel</button>
-              <button mat-button mat-raised-button color="primary"
-                [class.disabled]="!(calendar?.selectedDates?.start && calendar?.selectedDates?.end)"
-                (click)="updateCustomRange(dateInput,calendar.selectedDates);">&nbsp;Apply&nbsp;</button>
-            </div>
+        <div class="footer-content ndp-footer-content">
+          <span id="range-label-text">
+            {{calendar?.selectedDates?.start | date: dateFormat}}
+            @if (calendar?.selectedDates?.end) {
+              <span> - {{calendar.selectedDates?.end | date: dateFormat}} </span>
+            }
+          </span>
+          <div class="buttons">
+            <button mat-button mat-raised-button (click)="isCustomRange=false;">Cancel</button>
+            <button mat-button mat-raised-button color="primary"
+              [class.disabled]="!(calendar?.selectedDates?.start && calendar?.selectedDates?.end)"
+              (click)="updateCustomRange(dateInput,calendar.selectedDates);">&nbsp;Apply&nbsp;</button>
           </div>
         </div>
       </div>

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.html
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.html
@@ -65,21 +65,50 @@
           <div class="ndp-column-separator"></div>
         }
         <div class="mt-2 column-2"><lib-calendar [selectedDates]="selectedDates" #calendar [minDate]="minDate"
-            [maxDate]="maxDate"></lib-calendar></div>
+            [maxDate]="maxDate" (selectedDatesChange)="onCalendarSelectionChange($event)"></lib-calendar></div>
       </div>
       <div class="row-2 br-top">
         <div class="footer-content ndp-footer-content">
-          <span id="range-label-text">
-            {{calendar?.selectedDates?.start | date: dateFormat}}
-            @if (calendar?.selectedDates?.end) {
-              <span> - {{calendar.selectedDates?.end | date: dateFormat}} </span>
-            }
-          </span>
+          @if (enableEditableDates) {
+            <form class="ndp-date-inputs" [formGroup]="editableForm">
+              <mat-form-field class="ndp-date-field" subscriptSizing="dynamic">
+                <mat-label>Start</mat-label>
+                <input matInput formControlName="start" placeholder="e.g. now-7d"
+                  (blur)="commitEditableDates(calendar)"
+                  (keydown.enter)="applyEditableDates(dateInput, calendar)">
+                @if (editableForm.controls.start.hasError('required')) {
+                  <mat-error>Required</mat-error>
+                } @else if (editableForm.controls.start.hasError('invalidDate')) {
+                  <mat-error>Invalid date or expression</mat-error>
+                }
+              </mat-form-field>
+              <mat-form-field class="ndp-date-field" subscriptSizing="dynamic">
+                <mat-label>End</mat-label>
+                <input matInput formControlName="end" placeholder="e.g. now"
+                  (blur)="commitEditableDates(calendar)"
+                  (keydown.enter)="applyEditableDates(dateInput, calendar)">
+                @if (editableForm.controls.end.hasError('required')) {
+                  <mat-error>Required</mat-error>
+                } @else if (editableForm.controls.end.hasError('invalidDate')) {
+                  <mat-error>Invalid date or expression</mat-error>
+                } @else if (editableForm.hasError('rangeOrder')) {
+                  <mat-error>Start must be before end</mat-error>
+                }
+              </mat-form-field>
+            </form>
+          } @else {
+            <span id="range-label-text" class="ndp-range-label-text">
+              {{calendar?.selectedDates?.start | date: dateFormat}}
+              @if (calendar?.selectedDates?.end) {
+                <span> - {{calendar.selectedDates?.end | date: dateFormat}} </span>
+              }
+            </span>
+          }
           <div class="buttons">
             <button mat-button mat-raised-button (click)="isCustomRange=false;">Cancel</button>
             <button mat-button mat-raised-button color="primary"
-              [class.disabled]="!(calendar?.selectedDates?.start && calendar?.selectedDates?.end)"
-              (click)="updateCustomRange(dateInput,calendar.selectedDates);">&nbsp;Apply&nbsp;</button>
+              [class.disabled]="enableEditableDates ? editableForm.invalid : !(calendar?.selectedDates?.start && calendar?.selectedDates?.end)"
+              (click)="enableEditableDates && commitEditableDates(calendar); updateCustomRange(dateInput,calendar.selectedDates);">&nbsp;Apply&nbsp;</button>
           </div>
         </div>
       </div>

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
@@ -62,20 +62,31 @@ mat-list-item {
 .custom-calendar-container,
 .ndp-calendar-container {
   width: 100%;
-  display: block;
-  float: left;
 }
 
 .row-1,
 .row-2 {
   width: 100%;
-  display: block;
-  float: left;
   box-sizing: border-box;
+}
+
+// Flex layout lets the divider between the columns stretch to the row's
+// full height automatically (align-items: stretch), so differing column
+// heights never leave a gap.
+.row-1 {
+  display: flex;
+  align-items: stretch;
 }
 
 .row-2 {
   padding: 16px;
+}
+
+// Full-height divider between the options column and the calendar.
+// As a flex child it stretches to the row height with no positioning hacks.
+.ndp-column-separator {
+  flex: 0 0 1px;
+  background-color: var(--border-color, #ddd);
 }
 
 .footer-content, .ndp-footer-content {
@@ -94,26 +105,20 @@ mat-list-item {
 
 
 .column-1 {
-  width: 25%;
-  display: block;
-  float: left;
+  flex: 0 0 25%;
+  overflow: auto;
 }
 
 .column-2 {
-  width: 73%;
-  display: block;
-  float: left;
+  flex: 1 1 auto;
+  min-width: 0; // allow the calendar column to shrink below its content size
 }
 
+// When default options are hidden, column-1 and the separator aren't
+// rendered, so column-2's `flex: 1 1 auto` fills the row on its own.
 .without-default-opt {
   .column-1 {
     display: none;
-  }
-
-  .column-2 {
-    width: 100%;
-    display: block;
-    float: left;
   }
 }
 
@@ -122,7 +127,7 @@ mat-list-item {
     display: block;
 
     .buttons {
-      float: right;
+      justify-content: flex-end;
       margin-top: 20px;
     }
   }
@@ -133,32 +138,17 @@ mat-list-item {
 }
 
 @media (max-width: 650px) {
-
-  .column-1,
-  .column-2 {
-    width: 100%;
+  // Stack the columns; align-items: stretch then makes each full width.
+  .row-1 {
+    flex-direction: column;
   }
-}
 
-@media (min-width: 650px) {
   .column-1 {
-    width: 25%;
+    flex-basis: auto;
   }
 
-  .column-2 {
-    width: 74%;
-  }
-}
-
-.without-default-opt {
-  .column-1 {
+  .column-separator {
     display: none;
-  }
-
-  .column-2 {
-    width: 100%;
-    display: block;
-    float: left;
   }
 }
 

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
@@ -13,6 +13,16 @@ mat-list-item {
   height: 35px;
 }
 
+// Make the selected (activated) option clearly visible - the M3 theme leaves
+// the activated state of an action-list item unstyled. Consumers can override
+// via the --ndp-selected-option-bg custom property.
+mat-list-item.mdc-list-item--activated {
+  background-color: var(
+    --ndp-selected-option-bg,
+    var(--mat-sys-secondary-container, rgba(0, 0, 0, 0.08))
+  );
+}
+
 ::ng-deep.cdk-overlay-pane:has(.custom-ckd-container),
 ::ng-deep.cdk-overlay-pane:has(.ndp-cdk-container) {
   width: 100%;

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
@@ -71,28 +71,27 @@ mat-list-item {
   width: 100%;
   display: block;
   float: left;
+  box-sizing: border-box;
 }
 
 .row-2 {
-  padding: 0.7rem;
+  padding: 16px;
 }
 
-.footer-content {
-  width: 100%;
+.footer-content, .ndp-footer-content {
   align-items: center;
   display: flex;
   text-align: right;
   justify-content: end;
-  gap: 10px;
-  margin-right: 2rem;
+  gap: 16px; // Gap between label and buttons
   text-overflow: ellipsis;
+
+  .buttons {
+    display: flex;
+    gap: 8px; // Gap between buttons
+  }
 }
 
-.buttons {
-  margin-right: 1.5rem;
-  display: flex;
-  gap: 10px;
-}
 
 .column-1 {
   width: 25%;
@@ -119,17 +118,17 @@ mat-list-item {
 }
 
 @media (max-width: 400px) {
-  .footer-content {
+  .footer-content, .ndp-footer-content {
     display: block;
+
+    .buttons {
+      float: right;
+      margin-top: 20px;
+    }
   }
 
   #range-label-text {
     margin-right: 1.5rem;
-  }
-
-  .buttons {
-    float: right;
-    margin-top: 20px;
   }
 }
 

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
@@ -113,6 +113,18 @@ mat-list-item.mdc-list-item--activated {
   }
 }
 
+// Editable start/end inputs shown in the footer when enableEditableDates is on.
+.ndp-date-inputs {
+  display: flex;
+  gap: 8px;
+  margin-right: auto; // keep the inputs left, push the buttons to the right
+  align-items: flex-start; // don't stretch one field to match the other's error height
+}
+
+.ndp-date-field {
+  width: 150px;
+}
+
 
 .column-1 {
   flex: 0 0 25%;

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.scss
@@ -13,7 +13,8 @@ mat-list-item {
   height: 35px;
 }
 
-::ng-deep.cdk-overlay-pane:has(.custom-ckd-container) {
+::ng-deep.cdk-overlay-pane:has(.custom-ckd-container),
+::ng-deep.cdk-overlay-pane:has(.ndp-cdk-container) {
   width: 100%;
   background-color: var(--bg-color, white);
   max-height: 100vh;
@@ -58,7 +59,8 @@ mat-list-item {
   display: none;
 }
 
-.custom-calendar-container {
+.custom-calendar-container,
+.ndp-calendar-container {
   width: 100%;
   display: block;
   float: left;

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
@@ -19,8 +19,16 @@ import {
   signal,
   WritableSignal,
 } from '@angular/core';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
 import { DateRange } from '@angular/material/datepicker';
 import { SelectedDateEvent } from '../public-api';
+import { CalendarComponent } from './calendar/calendar.component';
 import { DATE_OPTION_TYPE } from './constant/date-filter-const';
 import { DEFAULT_DATE_OPTIONS } from './data/default-date-options';
 import { ISelectDateOption } from './model/select-date-option.model';
@@ -30,9 +38,13 @@ import {
   getDateWithOffset,
   getDaysInMonth,
   getFormattedDateString,
+  getRelativeExpr,
+  isSameDay,
+  parseDateByFormat,
   resetOptionSelection,
   selectCustomOption,
 } from './utils/date-picker-utilities';
+import { parseHumanDate } from './utils/human-date-parser';
 
 @Component({
   standalone: false,
@@ -59,6 +71,18 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
   @Input() listCdkConnectedOverlayOffsetX = 0;
   @Input() selectedOptionIndex = 3;
   @Input() displaySelectedLabel = false;
+  /**
+   * When true, the main input shows the human-readable expressions
+   * (e.g. `now-7d - now`) instead of the absolute date range. If
+   * `displaySelectedLabel` is also true, the label takes priority.
+   */
+  @Input() displaySelectedExpression = false;
+  /**
+   * When true, the custom-range footer shows two editable Material inputs
+   * (start / end) that accept dates in `dateFormat`, ISO 8601 durations
+   * (`p7d`), or date math (`now-7d`). When false, a read-only label is shown.
+   */
+  @Input() enableEditableDates = false;
   @Input() cdkConnectedOverlayPush = true;
   @Input() cdkConnectedOverlayPositions = [];
 
@@ -77,6 +101,32 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
   visibleOptions = computed(() =>
     this._dateOptions().filter((op) => op.isVisible)
   );
+
+  /**
+   * Reactive form backing the editable start/end inputs. Each control accepts
+   * a `dateFormat` date, an ISO 8601 duration, or a date-math expression; the
+   * group is invalid when either value is unparseable or start is after end.
+   */
+  editableForm = new FormGroup(
+    {
+      start: new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required, (c) => this.validateDateControl(c)],
+      }),
+      end: new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required, (c) => this.validateDateControl(c)],
+      }),
+    },
+    { validators: (g) => this.validateRange(g) }
+  );
+
+  // The raw expressions the user last committed via the editable inputs, kept
+  // so human-language input (e.g. `now-7d`) is shown again instead of being
+  // replaced by an absolute date - but only while it still resolves to the
+  // current range (see populateEditableForm).
+  private editableExpr: { start: string; end: string } | null = null;
+
   constructor() {}
 
   @Input()
@@ -117,7 +167,19 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
       this.isCustomRange = false;
       return;
     }
-    this.isDateOptionList = !this.isDateOptionList;
+    if (this.isDateOptionList) {
+      this.isDateOptionList = false;
+      return;
+    }
+    // When the active selection is a custom range, reopen straight into the
+    // custom-range view instead of the options list.
+    const selectedOption = this.dateDropDownOptions.find((o) => o.isSelected);
+    if (selectedOption?.optionType === DATE_OPTION_TYPE.CUSTOM) {
+      this.isCustomRange = true;
+      this.populateEditableForm();
+      return;
+    }
+    this.isDateOptionList = true;
   }
 
   /**
@@ -155,6 +217,7 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
     if (this.isCustomRange) {
       resetOptionSelection(this.dateDropDownOptions);
       selectCustomOption(this.dateDropDownOptions);
+      this.populateEditableForm();
     } else {
       resetOptionSelection(this.dateDropDownOptions, option);
       this.updateDateOnOptionSelect(option, input);
@@ -178,6 +241,178 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
    */
   toggleCustomDateRangeView(): void {
     this.isCustomRange = !this.isCustomRange;
+    if (this.isCustomRange) {
+      this.populateEditableForm();
+    }
+  }
+
+  /**
+   * Parses a single editable input value, accepting either a `dateFormat`
+   * date or one of the human formats (ISO 8601 duration, date math).
+   *
+   * @param value - The raw input string.
+   * @returns The parsed Date, or `null` if it cannot be parsed.
+   */
+  private parseInputValue(value: string): Date | null {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return parseDateByFormat(trimmed, this.dateFormat) ?? parseHumanDate(trimmed);
+  }
+
+  /**
+   * Validator for a single editable date control: valid when the value parses
+   * to a date. Empty values are left to the `required` validator.
+   */
+  private validateDateControl(control: AbstractControl): ValidationErrors | null {
+    const value = (control.value ?? '').trim();
+    if (!value) {
+      return null;
+    }
+    return this.parseInputValue(value) ? null : { invalidDate: true };
+  }
+
+  /**
+   * Group validator ensuring the parsed start date is not after the end date.
+   */
+  private validateRange(group: AbstractControl): ValidationErrors | null {
+    const start = this.parseInputValue(group.get('start')?.value ?? '');
+    const end = this.parseInputValue(group.get('end')?.value ?? '');
+    if (start && end && start > end) {
+      return { rangeOrder: true };
+    }
+    return null;
+  }
+
+  /**
+   * Commits the editable inputs to the calendar so the views and the Apply
+   * action reflect the typed values. No-op when editing is disabled or the
+   * form is invalid.
+   *
+   * @param calendar - The calendar component instance from the template.
+   */
+  commitEditableDates(calendar: CalendarComponent): void {
+    if (!this.enableEditableDates || this.editableForm.invalid) {
+      return;
+    }
+    const startRaw = this.editableForm.controls.start.value.trim();
+    const endRaw = this.editableForm.controls.end.value.trim();
+    const start = this.parseInputValue(startRaw);
+    const end = this.parseInputValue(endRaw);
+    if (!start || !end) {
+      return;
+    }
+    // Remember exactly what the user typed so the expression (e.g. `now-7d`)
+    // survives a reopen instead of being shown as a resolved absolute date.
+    this.editableExpr = { start: startRaw, end: endRaw };
+    calendar.selectedDates = new DateRange<Date>(start, end);
+    this.cdref.markForCheck();
+  }
+
+  /**
+   * Reflects a calendar (date-click) selection in the editable inputs as
+   * absolute dates. A calendar pick is an explicit absolute selection, so any
+   * remembered expression is cleared and the inputs show formatted dates.
+   *
+   * @param range - The range emitted by the calendar.
+   */
+  onCalendarSelectionChange(range: DateRange<Date>): void {
+    if (!this.enableEditableDates) {
+      return;
+    }
+    this.editableExpr = null;
+    this.editableForm.setValue({
+      start: range.start ? getDateString(range.start, this.dateFormat) : '',
+      end: range.end ? getDateString(range.end, this.dateFormat) : '',
+    });
+    this.cdref.markForCheck();
+  }
+
+  /**
+   * Commits the editable inputs and applies the range, closing the panel -
+   * the same as clicking Apply. Used for the Enter key. No-op when editing is
+   * disabled or the form is invalid, so Enter never closes with bad input.
+   *
+   * @param input - The main date input element to update.
+   * @param calendar - The calendar component instance from the template.
+   */
+  applyEditableDates(input: HTMLInputElement, calendar: CalendarComponent): void {
+    if (!this.enableEditableDates || this.editableForm.invalid) {
+      return;
+    }
+    this.commitEditableDates(calendar);
+    this.updateCustomRange(input, calendar.selectedDates);
+  }
+
+  /**
+   * Pre-fills the editable inputs from the current selection: relative
+   * expressions for a day-diff option (e.g. `now-7d` .. `now`), otherwise the
+   * absolute formatted dates.
+   */
+  private populateEditableForm(): void {
+    if (!this.enableEditableDates) {
+      return;
+    }
+    const range = this.selectedDates;
+    if (range?.start && range?.end) {
+      const option =
+        this.dateDropDownOptions.find((o) => o.isSelected) ?? null;
+      this.editableForm.setValue(
+        this.resolveDisplayExpr(range.start, range.end, option)
+      );
+    } else {
+      this.editableForm.setValue({ start: '', end: '' });
+    }
+  }
+
+  /**
+   * Resolves the human-readable start/end expressions for a range. Prefers the
+   * user's own committed expression (when it still resolves to this range),
+   * then the relative form of a day-diff option, and finally the absolute
+   * formatted dates. Shared by the editable inputs and the emitted event.
+   *
+   * @param start - Range start date.
+   * @param end - Range end date.
+   * @param opt - The associated date option, if any.
+   * @returns The start and end expression strings.
+   */
+  private resolveDisplayExpr(
+    start: Date,
+    end: Date,
+    opt: ISelectDateOption | null
+  ): { start: string; end: string } {
+    if (this.editableExpr && this.exprMatchesDates(this.editableExpr, start, end)) {
+      return { start: this.editableExpr.start, end: this.editableExpr.end };
+    }
+    const optionExpr = getRelativeExpr(opt);
+    if (optionExpr) {
+      return optionExpr;
+    }
+    return {
+      start: getDateString(start, this.dateFormat),
+      end: getDateString(end, this.dateFormat),
+    };
+  }
+
+  /**
+   * Checks whether a saved expression still resolves (to day precision) to the
+   * given dates, so a stale expression is not reused after the range changed
+   * by other means.
+   */
+  private exprMatchesDates(
+    expr: { start: string; end: string },
+    start: Date,
+    end: Date
+  ): boolean {
+    const exprStart = this.parseInputValue(expr.start);
+    const exprEnd = this.parseInputValue(expr.end);
+    return (
+      !!exprStart &&
+      !!exprEnd &&
+      isSameDay(exprStart, start) &&
+      isSameDay(exprEnd, end)
+    );
   }
 
   /**
@@ -197,6 +432,8 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
     const selectedDateEventData: SelectedDateEvent = {
       range: null,
       selectedOption: null,
+      startExpr: null,
+      endExpr: null,
     };
     this.onDateSelectionChanged.emit(selectedDateEventData);
   }
@@ -304,17 +541,26 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
     const range = new DateRange(start, end);
     this.selectedDates = range;
 
-    const label = this.displaySelectedLabel ? opt?.optionLabel : null;
+    const expr = this.resolveDisplayExpr(start, end, opt);
     const rangeLabel = `${getDateString(
       start,
       this.dateFormat
     )} - ${getDateString(end, this.dateFormat)}`;
 
-    input.value = label ?? rangeLabel;
+    if (this.displaySelectedLabel && opt?.optionLabel) {
+      input.value = opt.optionLabel;
+    } else if (this.displaySelectedExpression) {
+      input.value = `${expr.start} - ${expr.end}`;
+    } else {
+      input.value = rangeLabel;
+    }
+
     this.onDateSelectionChanged.emit({
       range,
       selectedOption:
         this.dateDropDownOptions.find((o) => o.isSelected) ?? null,
+      startExpr: expr.start,
+      endExpr: expr.end,
     });
     this.cdref.markForCheck();
   }

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
@@ -105,19 +105,16 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
 
   /**
    * Toggles the visibility of the default date option list.
-   * If the custom option is selected, toggles the custom date range view instead.
+   * If the custom range panel is open, closes it instead.
    *
    * @param event Optional MouseEvent triggering the toggle.
    */
   toggleDateOptionSelectionList(event?: MouseEvent): void {
     event?.preventDefault();
     event?.stopImmediatePropagation();
-    const isCustomSelected =
-      this.dateDropDownOptions.find((option) => option.isSelected)
-        ?.optionType === DATE_OPTION_TYPE.CUSTOM;
 
-    if (isCustomSelected) {
-      this.toggleCustomDateRangeView();
+    if (this.isCustomRange) {
+      this.isCustomRange = false;
       return;
     }
     this.isDateOptionList = !this.isDateOptionList;
@@ -154,7 +151,10 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
   updateSelection(option: ISelectDateOption, input: HTMLInputElement): void {
     this.isDateOptionList = false;
     this.isCustomRange = option.optionType === DATE_OPTION_TYPE.CUSTOM;
-    if (!this.isCustomRange) {
+    if (this.isCustomRange) {
+      resetOptionSelection(this.dateDropDownOptions);
+      selectCustomOption(this.dateDropDownOptions);
+    } else {
       resetOptionSelection(this.dateDropDownOptions, option);
       this.updateDateOnOptionSelect(option, input);
     }

--- a/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.component.ts
@@ -134,6 +134,7 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
     if (this.isCustomRange) {
       resetOptionSelection(this.dateDropDownOptions);
       selectCustomOption(this.dateDropDownOptions);
+      this.syncOptionSelection();
       this.isCustomRange = false;
     }
 
@@ -158,7 +159,18 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
       resetOptionSelection(this.dateDropDownOptions, option);
       this.updateDateOnOptionSelect(option, input);
     }
+    this.syncOptionSelection();
     this.cdref.markForCheck();
+  }
+
+  /**
+   * Re-emits the options signal after an in-place selection change so the
+   * OnPush views (bound to the `visibleOptions` computed) reliably reflect the
+   * new `isSelected` state - the same notification the initial signal `set`
+   * provides.
+   */
+  private syncOptionSelection(): void {
+    this._dateOptions.update((options) => [...options]);
   }
 
   /**
@@ -179,6 +191,7 @@ export class NgDatePickerComponent implements OnInit, AfterViewInit {
     this.maxDate = getDateWithOffset(10);
     this.selectedDates = null;
     resetOptionSelection(this.dateDropDownOptions);
+    this.syncOptionSelection();
     this.clearDateInput();
     this.cdref.markForCheck();
     const selectedDateEventData: SelectedDateEvent = {

--- a/projects/ng-date-picker/src/lib/ng-date-picker.module.ts
+++ b/projects/ng-date-picker/src/lib/ng-date-picker.module.ts
@@ -6,7 +6,7 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatNativeDateModule } from '@angular/material/core';
@@ -24,6 +24,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     MatDatepickerModule,
     MatNativeDateModule,
     MatInputModule,

--- a/projects/ng-date-picker/src/lib/utils/date-picker-utilities.ts
+++ b/projects/ng-date-picker/src/lib/utils/date-picker-utilities.ts
@@ -113,6 +113,118 @@ export function createOption(
   };
 }
 
+/** Escapes a string so it can be used as a literal inside a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Returns true when both dates fall on the same calendar day. */
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/**
+ * Parses a date string against an Angular-style date format (the subset of
+ * tokens `yyyy`, `yy`, `MM`, `M`, `dd`, `d`). Returns `null` if the string
+ * does not match the format or is not a real calendar date (e.g. `31/02`).
+ *
+ * @param value - The user-entered date string.
+ * @param format - The expected format, e.g. `dd/MM/yyyy`.
+ * @returns The parsed Date, or `null` if it does not match.
+ */
+export function parseDateByFormat(value: string, format: string): Date | null {
+  const tokens: string[] = [];
+  const tokenRegex = /yyyy|yy|MM|M|dd|d/g;
+  let pattern = '^';
+  let lastIndex = 0;
+  let token: RegExpExecArray | null;
+  while ((token = tokenRegex.exec(format)) !== null) {
+    pattern += escapeRegExp(format.slice(lastIndex, token.index));
+    switch (token[0]) {
+      case 'yyyy':
+        pattern += '(\\d{4})';
+        break;
+      case 'yy':
+        pattern += '(\\d{2})';
+        break;
+      case 'MM':
+      case 'dd':
+        pattern += '(\\d{2})';
+        break;
+      default: // 'M' or 'd'
+        pattern += '(\\d{1,2})';
+        break;
+    }
+    tokens.push(token[0]);
+    lastIndex = token.index + token[0].length;
+  }
+  pattern += escapeRegExp(format.slice(lastIndex)) + '$';
+
+  const match = new RegExp(pattern).exec(value.trim());
+  if (!match) {
+    return null;
+  }
+
+  let year = NaN;
+  let month = NaN;
+  let day = NaN;
+  tokens.forEach((token, index) => {
+    const part = parseInt(match[index + 1], 10);
+    if (token.startsWith('y')) {
+      year = token === 'yy' ? 2000 + part : part;
+    } else if (token.startsWith('M')) {
+      month = part - 1;
+    } else {
+      day = part;
+    }
+  });
+  if (isNaN(year) || isNaN(month) || isNaN(day)) {
+    return null;
+  }
+
+  const date = new Date(year, month, day);
+  // Reject overflow dates such as 31/02 that Date silently rolls over.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+}
+
+/**
+ * Derives the relative date-math expressions (start/end) for a date option,
+ * for display in editable inputs. Only day-diff options have a clean relative
+ * form (e.g. `Last 7 Days` -> `now-7d` .. `now`); an explicit `startExpr` /
+ * `endExpr` on the option overrides the derived value. Returns `null` when no
+ * relative representation applies, so the caller falls back to absolute dates.
+ *
+ * @param option - The selected date option.
+ * @returns `{ start, end }` expressions, or `null`.
+ */
+export function getRelativeExpr(
+  option?: ISelectDateOption | null
+): { start: string; end: string } | null {
+  if (!option) {
+    return null;
+  }
+  if (option.startExpr && option.endExpr) {
+    return { start: option.startExpr, end: option.endExpr };
+  }
+  if (option.optionType !== DATE_OPTION_TYPE.DATE_DIFF) {
+    return null;
+  }
+  const diff = option.dateDiff ?? 0;
+  const start = diff === 0 ? 'now' : `now${diff > 0 ? '+' : ''}${diff}d`;
+  return { start, end: 'now' };
+}
+
 /**
  * Returns the date of the next month based on the given date.
  *

--- a/projects/ng-date-picker/src/lib/utils/human-date-parser.ts
+++ b/projects/ng-date-picker/src/lib/utils/human-date-parser.ts
@@ -1,0 +1,266 @@
+/**
+ * Human-readable timedelta / date parsing utilities.
+ *
+ * Three independent parsers plus a public entry point that combines them:
+ *  1. {@link parseIso8601Duration} - ISO 8601 durations (`P7D`, `PT1H30M`),
+ *     strict uppercase as required by the spec.
+ *  2. {@link parseDateMath} - Grafana/Elasticsearch style date math (`now-7d`).
+ *  3. {@link parseNaturalLanguage} - natural language (`7 days ago`) via a
+ *     parser the host app registers with {@link setNaturalLanguageParser}
+ *     (typically `chrono-node`). No parser registered means this step is a
+ *     no-op, so the library never depends on `chrono-node` directly.
+ *
+ * {@link parseHumanDate} tries all three and accepts lowercase ISO durations.
+ */
+
+/**
+ * A calendar duration parsed from an ISO 8601 duration string.
+ * Each field defaults to 0 when its component is absent.
+ */
+export interface Duration {
+  years: number;
+  months: number;
+  weeks: number;
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
+
+/**
+ * Options for {@link parseHumanDate}.
+ */
+export interface ParseHumanDateOptions {
+  /** Reference "now" used to resolve relative expressions. Defaults to `new Date()`. */
+  base?: Date;
+  /**
+   * Direction applied to a bare ISO 8601 duration: `-1` resolves it to the
+   * past (`base - duration`, e.g. "last 7 days"), `1` to the future.
+   * Defaults to `-1` to match this picker's "Last N days" vocabulary.
+   */
+  durationSign?: 1 | -1;
+  /**
+   * Whether to fall back to the registered natural-language parser.
+   * Defaults to `true`. Has no effect if no parser was registered.
+   */
+  useNaturalLanguage?: boolean;
+}
+
+// ISO 8601 duration. Designators are uppercase per spec; `M` is months before
+// the `T` separator and minutes after it. Fractions allow `.` or `,`.
+// The `(?!$)` guards reject the degenerate `P` and `PT` strings.
+const ISO_8601_DURATION =
+  /^P(?!$)(?:(\d+(?:[.,]\d+)?)Y)?(?:(\d+(?:[.,]\d+)?)M)?(?:(\d+(?:[.,]\d+)?)W)?(?:(\d+(?:[.,]\d+)?)D)?(?:T(?!$)(?:(\d+(?:[.,]\d+)?)H)?(?:(\d+(?:[.,]\d+)?)M)?(?:(\d+(?:[.,]\d+)?)S)?)?$/;
+
+// Date math: `now` followed by zero or more `±N<unit>` operations.
+// Units: y=year, M=month, w=week, d=day, h=hour, m=minute, s=second.
+const DATE_MATH = /^now((?:[+-]\d+[yMwdhms])*)$/;
+const DATE_MATH_OP = /([+-])(\d+)([yMwdhms])/g;
+
+/**
+ * Parses a strict, uppercase ISO 8601 duration string into a {@link Duration}.
+ *
+ * Spec-compliant: designators must be uppercase, so `P7D` parses but `p7d`
+ * does not. Use {@link parseHumanDate} if you need lenient (lowercase) input.
+ *
+ * @param input - Candidate ISO 8601 duration, e.g. `P1Y2M10DT2H30M`.
+ * @returns The parsed duration, or `null` if the string is not a valid duration.
+ */
+export function parseIso8601Duration(input: string): Duration | null {
+  const match = ISO_8601_DURATION.exec(input);
+  if (!match) {
+    return null;
+  }
+  const num = (value: string | undefined): number =>
+    value === undefined ? 0 : parseFloat(value.replace(',', '.'));
+  return {
+    years: num(match[1]),
+    months: num(match[2]),
+    weeks: num(match[3]),
+    days: num(match[4]),
+    hours: num(match[5]),
+    minutes: num(match[6]),
+    seconds: num(match[7]),
+  };
+}
+
+/**
+ * Applies a single date-math unit to a date, returning a new Date.
+ * Date-level units use calendar-aware setters; the caller guarantees `unit`.
+ */
+function applyUnit(date: Date, unit: string, amount: number): Date {
+  const result = new Date(date.getTime());
+  switch (unit) {
+    case 'y':
+      result.setFullYear(result.getFullYear() + amount);
+      break;
+    case 'M':
+      result.setMonth(result.getMonth() + amount);
+      break;
+    case 'w':
+      result.setDate(result.getDate() + amount * 7);
+      break;
+    case 'd':
+      result.setDate(result.getDate() + amount);
+      break;
+    case 'h':
+      result.setHours(result.getHours() + amount);
+      break;
+    case 'm':
+      result.setMinutes(result.getMinutes() + amount);
+      break;
+    case 's':
+      result.setSeconds(result.getSeconds() + amount);
+      break;
+  }
+  return result;
+}
+
+/**
+ * Applies a {@link Duration} to a base date, returning a new Date.
+ *
+ * Calendar units (years, months, weeks, days) use Date setters and are
+ * therefore truncated to integers; sub-day units (hours, minutes, seconds)
+ * are applied as milliseconds and preserve fractional values.
+ *
+ * @param base - The date to offset from.
+ * @param duration - The duration to apply.
+ * @param sign - `1` to add (future), `-1` to subtract (past). Defaults to `1`.
+ * @returns A new Date offset from `base`.
+ */
+export function addDuration(base: Date, duration: Duration, sign: 1 | -1 = 1): Date {
+  let result = new Date(base.getTime());
+  result = applyUnit(result, 'y', sign * duration.years);
+  result = applyUnit(result, 'M', sign * duration.months);
+  result.setDate(result.getDate() + sign * (duration.weeks * 7 + duration.days));
+  const subDayMs =
+    (duration.hours * 3600 + duration.minutes * 60 + duration.seconds) * 1000;
+  result.setTime(result.getTime() + sign * subDayMs);
+  return result;
+}
+
+/**
+ * Parses a Grafana/Elasticsearch style date-math expression into a Date.
+ *
+ * Supports `now` optionally followed by `±N<unit>` operations applied left to
+ * right, e.g. `now`, `now-7d`, `now-1M+15d`. Units: `y M w d h m s`
+ * (note `M` = month, `m` = minute). Snapping (`/d`) is not supported.
+ *
+ * @param input - The date-math expression.
+ * @param base - Reference "now". Defaults to `new Date()`.
+ * @returns The resolved Date, or `null` if the expression is not date math.
+ */
+export function parseDateMath(input: string, base: Date = new Date()): Date | null {
+  const match = DATE_MATH.exec(input);
+  if (!match) {
+    return null;
+  }
+  let result = new Date(base.getTime());
+  const operations = match[1];
+  DATE_MATH_OP.lastIndex = 0;
+  let op: RegExpExecArray | null;
+  while ((op = DATE_MATH_OP.exec(operations)) !== null) {
+    const sign = op[1] === '-' ? -1 : 1;
+    const amount = parseInt(op[2], 10);
+    result = applyUnit(result, op[3], sign * amount);
+  }
+  return result;
+}
+
+/**
+ * Signature of a natural-language date parser, matching `chrono-node`'s
+ * `parseDate(text, ref)` export.
+ */
+export type NaturalLanguageParser = (text: string, ref?: Date) => Date | null;
+
+// A parser registered by the host app via `setNaturalLanguageParser`. The
+// library never imports `chrono-node` itself, keeping it a truly optional
+// dependency that works the same in browser, SSR, and Node builds.
+let registeredParser: NaturalLanguageParser | null = null;
+
+/**
+ * Registers a natural-language parser (typically `chrono-node`'s `parseDate`)
+ * for {@link parseNaturalLanguage} / {@link parseHumanDate} to use.
+ *
+ * The consumer imports the package themselves, so their bundler resolves it
+ * and this library never references it directly. Call with `null` to disable.
+ *
+ * @example
+ * import * as chrono from 'chrono-node';
+ * setNaturalLanguageParser((text, ref) => chrono.parseDate(text, ref));
+ *
+ * @param parser - The parser to use, or `null` to disable.
+ */
+export function setNaturalLanguageParser(
+  parser: NaturalLanguageParser | null
+): void {
+  registeredParser = parser;
+}
+
+/**
+ * Parses natural language (`7 days ago`, `next friday`) using the parser
+ * registered via {@link setNaturalLanguageParser}.
+ *
+ * @param input - The natural-language date expression.
+ * @param base - Reference date the parser resolves against. Defaults to `new Date()`.
+ * @returns The parsed Date, or `null` if no parser is registered or the text
+ *          could not be parsed.
+ */
+export function parseNaturalLanguage(
+  input: string,
+  base: Date = new Date()
+): Date | null {
+  if (!registeredParser) {
+    return null;
+  }
+  try {
+    return registeredParser(input, base) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Public entry point: parses a human-readable date/duration expression into a
+ * concrete Date by trying, in order, date math, ISO 8601 duration, then
+ * natural language via the registered parser.
+ *
+ * Unlike {@link parseIso8601Duration}, this accepts lowercase ISO durations
+ * (`p7d`) by upper-casing the input before the ISO attempt.
+ *
+ * @param input - The expression, e.g. `now-7d`, `P7D`, `p7d`, `3 weeks ago`.
+ * @param options - See {@link ParseHumanDateOptions}.
+ * @returns The parsed Date, or `null` if nothing matched.
+ */
+export function parseHumanDate(
+  input: string,
+  options: ParseHumanDateOptions = {}
+): Date | null {
+  const base = options.base ?? new Date();
+  const durationSign = options.durationSign ?? -1;
+  const useNaturalLanguage = options.useNaturalLanguage ?? true;
+
+  const trimmed = input?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // 1. Date math (`now-7d`) - unambiguous and cheap.
+  const fromDateMath = parseDateMath(trimmed, base);
+  if (fromDateMath) {
+    return fromDateMath;
+  }
+
+  // 2. ISO 8601 duration - upper-cased so lowercase input is accepted here.
+  const duration = parseIso8601Duration(trimmed.toUpperCase());
+  if (duration) {
+    return addDuration(base, duration, durationSign);
+  }
+
+  // 3. Natural language via the registered parser, if any.
+  if (useNaturalLanguage) {
+    return parseNaturalLanguage(trimmed, base);
+  }
+
+  return null;
+}

--- a/projects/ng-date-picker/src/public-api.ts
+++ b/projects/ng-date-picker/src/public-api.ts
@@ -10,3 +10,4 @@ export * from './lib/model/select-date-option.model';
 export * from './lib/ng-date-picker.module';
 export * from './lib/constant/date-filter-const';
 export * from './lib/model/date-selection-event.model';
+export * from './lib/utils/human-date-parser';


### PR DESCRIPTION
- Added `ndp-` class prefix to replace all `custom-` prefixs. `custom-` is deprecated and may be removed in a future version.
- Fixed overlapping dropdown issue. If you selected custom range and click the form field again, it'd open the list dropdown overtop. Now it behaves as a single dropdown.
- Fixed dropdown not highlighting last selected option.
- Fixed a few style issues
    - Replaced float with flexbox
    - Inconsistent padding
    - Ensured vertical line is not bound to the height of `column-1` which caused a gap in some scenarios
    - Made column-1 scrollable
- Added optional human timedelta parsing

<img width="803" height="699" alt="image" src="https://github.com/user-attachments/assets/69adb568-3c2f-4e24-bd79-137b87ab8683" />
<img width="751" height="594" alt="image" src="https://github.com/user-attachments/assets/8ddd197d-f0a6-47c8-9536-c3570e6e6c1d" />
<img width="323" height="536" alt="image" src="https://github.com/user-attachments/assets/acae5fb1-1ca6-4364-ae59-2676f5a6411a" />


Some commits were created with help from Claude. I did review, but I'm no longer an Angular expert.
